### PR TITLE
Add `tailwind-color-alpha` (#217)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@
 - [Dark Mode with Class](https://github.com/danestves/tailwindcss-darkmode) - Adds `dark` variants based on CSS classes.
 - [CSS Logical Properties](https://github.com/omarkhatibco/tailwind-css-logical-properties) - Generate classnames for CSS Logical Properties for margin, padding, border-width, border-raduis, text-align, float & writing-mode.
 - [CSS Scroll Snap](https://github.com/hawezo/tailwindcss-scroll-snap) - Adds `scroll-snap` utilities.
++ [CSS Alpha Colors](https://github.com/soueuls/tailwind-color-alpha) - Adds opacity variants to existing colors.
 
 > 🛑 - _The functionalities these plugins below offer have been fully or partially implemented in the latest Tailwind CSS versions._
 


### PR DESCRIPTION
* Add `tailwind-color-alpha`

I made this simple plugin which works with Tailwind 1.2, it will combine all your colors with your opacity settings and generate the corresponding rgba colors.

* Update readme.md

Co-Authored-By: Haew <hi@haew.xyz>